### PR TITLE
adds necessary attribute for dropdown

### DIFF
--- a/src/app/Attributes/Meta.php
+++ b/src/app/Attributes/Meta.php
@@ -10,7 +10,7 @@ class Meta
         'options', 'multiple', 'custom', 'content', 'step', 'min', 'max', 'disabled', 'readonly',
         'hidden', 'source', 'format', 'time', 'rows', 'placeholder', 'trackBy', 'label', 'tooltip',
         'symbol', 'precision', 'thousand', 'decimal', 'positive', 'negative', 'zero', 'resize',
-        'translated', 'time12hr', 'disable-clear', 'params',
+        'translated', 'time12hr', 'disable-clear', 'params', 'style',
     ];
 
     const Types = [


### PR DESCRIPTION
Adds a new attribute `style`. It is an optional attribute that can only be used by `DropdownField.vue` as follows:
* define a source Enum:
```
class Priorities extends Enum
{
    // options
    const High = 1
}
```
* define a class enum Enum for each option:
```
class PriorityClasses extends Enum
{
    protected static $data = [
        // others
        Priorities::High => 'is-danger'
    ]
}
```
* expose both of them to the front-end ( `PriorityClasses => 'priorityClasses'`)
* in your form template set `style` meta attribute for the dropdown field as 'priorityClasses'
* your options should have the specified class applied
