### PR TITLE
implements hidden actions

### DIFF
--- a/src/Attributes/Structure.php
+++ b/src/Attributes/Structure.php
@@ -7,9 +7,9 @@ class Structure
     public const Mandatory = ['method', 'sections', 'routeParams'];
 
     public const Optional = [
-        'actions', 'authorize', 'autosave', 'clearErrorsControl',  'debounce',
-        'dividerTitlePlacement', 'icon', 'labels', 'params', 'routePrefix',
-        'routes', 'tabs', 'title',
+        'actions', 'authorize', 'autosave', 'clearErrorsControl', 'debounce',
+        'dividerTitlePlacement', 'hiddenActions', 'icon', 'labels', 'params',
+        'routePrefix', 'routes', 'tabs', 'title',
     ];
 
     public const SectionMandatory = ['columns', 'fields'];

--- a/src/Services/Builder.php
+++ b/src/Services/Builder.php
@@ -187,6 +187,8 @@ class Builder
         return [
             'button' => config('enso.forms.buttons.'.$action),
             'forbidden' => $this->isForbidden($route),
+            'hidden' => $this->template->has('hiddenActions') &&
+                $this->template->get('hiddenActions')->contains($action),
             $routeOrPath => $value,
         ];
     }

--- a/src/Services/Form.php
+++ b/src/Services/Form.php
@@ -146,6 +146,13 @@ class Form
         return $this;
     }
 
+    public function hiddenActions(string|array $actions): self
+    {
+        $this->template->set('hiddenActions', new Obj($actions));
+
+        return $this;
+    }
+
     public function hideTab($tabs): self
     {
         $this->tabVisibility($tabs, $hidden = true);


### PR DESCRIPTION
This feature could be useful in scenarios where someone needs to call the form's submit method procedurally, without displaying the actual Update/Store button.

May be improved with tests and validations ( even though nothing breaks if providing invalid actions ) but let me know what you think first.

refs https://github.com/enso-ui/forms/pull/36/files